### PR TITLE
MSSQL to handle duplicated columns names like other DB clients

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -65,6 +65,8 @@ export async function queryStream(req, res, pool) {
   try {
     await new Promise((resolve, reject) => {
       const request = new mssql.Request(db);
+      // We are using the arrayRowMode to handle potential duplicated column name.
+      // See: https://github.com/tediousjs/node-mssql#handling-duplicate-column-names
       request.arrayRowMode = true;
       const stream = request.toReadableStream();
 

--- a/test/mssql.test.js
+++ b/test/mssql.test.js
@@ -123,6 +123,31 @@ describe("mssql", () => {
         }
       });
     });
+    it("should handle duplicated column names", () => {
+      return new Promise(async (resolve, reject) => {
+        const req = new MockReq({method: "POST", url: "/query-stream"}).end({
+          sql: "SELECT 1 as _a1, 2 as _a1 FROM test.SalesLT.SalesOrderDetail",
+          params: [],
+        });
+
+        const res = new MockRes(onEnd);
+
+        const index = mssql(credentials);
+        await index(req, res);
+
+        function onEnd() {
+          const [schema, row] = this._getString().split("\n");
+
+          expect(row).to.equal(
+            JSON.stringify({
+              _a1: 2,
+            })
+          );
+
+          resolve();
+        }
+      });
+    });
     it("should select the last value of any detected duplicated columns", () => {
       return new Promise(async (resolve, reject) => {
         const req = new MockReq({method: "POST", url: "/query-stream"}).end({


### PR DESCRIPTION
Resolves https://github.com/orgs/observablehq/projects/66/views/11. 

**Desciprition**

The `tedious/mssql` client is exposing the following API to handle duplicated columns: https://github.com/orgs/observablehq/projects/66/views/11. 

Refactored, the query stream to use the `arrayRowMode` and `deduplicate` the columns values for each row in a new `Transform` step before the `JSONStream.stringify` step.