### PR TITLE
Add CONNECT to allowed sql verbs

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -8,7 +8,7 @@ const TYPES = mssql.TYPES;
 
 const pools = new Map();
 
-const READ_ONLY = new Set(["SELECT", "USAGE"]);
+const READ_ONLY = new Set(["SELECT", "USAGE", "CONNECT"]);
 
 const ajv = new Ajv();
 const validate = ajv.compile({


### PR DESCRIPTION
Resolves https://github.com/orgs/observablehq/projects/66/views/11.

**Description**
When a user registers a new client, `observable` is making a call to the `database-proxy` to ensure the user does not have a too permissive role. `MSSQL` has its own SQL Syntax when it comes to permission, it needs to include the basic `CONNECT` one.