### PR TITLE
Fix chunk

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -101,17 +101,21 @@ export async function queryStream(req, res, pool) {
           new Transform({
             objectMode: true,
             transform(chunk, encoding, cb) {
-              const row = chunk.reduce((acc, r, idx) => {
-                const key = columnNameMap.get(idx);
-                return {...acc, [key]: r};
-              }, {});
-
-              cb(null, row);
+              if (Array.isArray(chunk)) {
+                const row = chunk.reduce((acc, r, idx) => {
+                  const key = columnNameMap.get(idx);
+                  return {...acc, [key]: r};
+                }, {});
+                cb(null, row);
+              } else {
+                cb(new Error("row has unexpected format"), chunk);
+              }
             },
           })
         )
         .pipe(JSONStream.stringify("", "\n", "\n"))
         .pipe(res);
+
       stream.on("done", () => {
         resolve();
       });


### PR DESCRIPTION
Sometime chunk is not an array, for example with such `XML` odd query: 

```SQL
select (
  SELECT SalesOrderID, ModifiedDate 
  FROM test.SalesLT.SalesOrderDetail
  WHERE SalesOrderID = 000000000000000
  for xml auto, type) 
  items
for xml path('root')
```
Also passing down the error via the callback would prevent a crash if the transform encounter issue.