### PR TITLE
No error on stream

### DIFF
--- a/lib/mssql.js
+++ b/lib/mssql.js
@@ -101,15 +101,18 @@ export async function queryStream(req, res, pool) {
           new Transform({
             objectMode: true,
             transform(chunk, encoding, cb) {
-              if (Array.isArray(chunk)) {
-                const row = chunk.reduce((acc, r, idx) => {
+              let row = null;
+              try {
+                row = chunk.reduce((acc, r, idx) => {
                   const key = columnNameMap.get(idx);
                   return {...acc, [key]: r};
                 }, {});
-                cb(null, row);
-              } else {
-                cb(null, undefined);
+              } catch (e) {
+                console.error("row has unexpected format");
+                // TODO: Add error handling once server supports handling error for in flight streamed response
+                // cb(new Error(e));
               }
+              cb(null, row);
             },
           })
         )


### PR DESCRIPTION
Throwing error from a `stream` is currently causing the data-connector application to crash. Removing the error for now. We will need to fix the way these errors are handled by the micro service library.