### PR TITLE
Moved Oracle DB types mapping to the OracleSingleton class

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -237,7 +237,7 @@ export default async ({url, username, password}) => {
 
 // See https://oracle.github.io/node-oracledb/doc/api.html#-312-oracle-database-type-constants
 function dataTypeSchema({type}) {
-  const types = OracleSingleton.types();
+  const types = OracleSingleton.types;
   if (types.has(type)) {
     return types.get(type);
   }


### PR DESCRIPTION
The `OracleSingleton.getInstance` method is `async`, as it returns a Promise that resolves to the `oracledb` modules. 

This breaks the `dataTypeSchema` method, as it is not an `async` function. To avoid having to `await` to get the `oracledb` module to be loaded in that function, we added a `static types` property to the `OracleSingleton` class. 

The `types` are mapped as part of the `initialize` method after the module is loaded. We can then access the `OracleSingleton.types` by using the `OracleSingleton.getTypes` method synchronously. 

It also makes the the `dataTypeSchema` function much simple.

Since the `dataTypeSchema` function is called as part of the response to a query made by the client, it is safe to assume that the client has been initialized and is ready to be used at that point.
