### PR TITLE
Add sql server to credentials prompt command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -56,7 +56,7 @@ export async function add(argv, reset = false) {
   // DB credentials
   if (!reset) {
     url = await question(
-      "PostgreSQL, MySQL, or Snowflake Database URL (including username and password): "
+      "PostgreSQL, MySQL, Snowflake or SQL Server Database URL (including username and password): "
     );
   }
 


### PR DESCRIPTION
`SQL Server` option was missing when prompting the user to enter credentials using the `CLI` workflows.