### PR TITLE
Fix unhandled error with openSession

### DIFF
--- a/lib/databricks.js
+++ b/lib/databricks.js
@@ -31,7 +31,12 @@ export class DatabricksSingleton {
  * */
 export async function check(req, res, connection) {
   try {
-    await connection.openSession();
+    // If a session fails to open, currently the error is not propagating correctly.
+    // see: https://github.com/databricks/databricks-sql-nodejs/issues/77
+    await new Promise((resolve, reject) => {
+      connection.on("error", reject).openSession().then(resolve);
+    });
+
     return {ok: true};
   } catch (e) {
     throw e;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "observable-database-proxy": "./bin/observable-database-proxy.js"
   },
   "dependencies": {
-    "@databricks/sql": "^1.0.0",
+    "@databricks/sql": "https://github.com/databricks/databricks-sql-nodejs#3df43263184aeaab1b473e65dfe08cb8fa9daaf4",
     "JSONStream": "^1.3.5",
     "ajv": "^8.11.0",
     "micro": "^9.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,10 +1119,9 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@databricks/sql@^1.0.0":
+"@databricks/sql@https://github.com/databricks/databricks-sql-nodejs#3df43263184aeaab1b473e65dfe08cb8fa9daaf4":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@databricks/sql/-/sql-1.0.0.tgz#aa12de5a364c1d15584de9807949e5ac957cef2d"
-  integrity sha512-73NVxH0tAVV/u2ns0T3tYpOvvAQ5kTFoQZATHpSlBBQRwTPKmzvHsq+jbpex/wqescoQ6TW9ZRf7W8sO4w2z4g==
+  resolved "https://github.com/databricks/databricks-sql-nodejs#3df43263184aeaab1b473e65dfe08cb8fa9daaf4"
   dependencies:
     commander "^9.3.0"
     node-int64 "^0.4.0"


### PR DESCRIPTION
The issue is very well documented here: https://github.com/databricks/databricks-sql-nodejs/issues/77
and https://github.com/databricks/databricks-sql-nodejs/issues/85. 

This applies the latest patch for the `@databricks/sql` library and fix the unhandled error when opening a session that would cause any consumer of the databricks client (i.e: `data-connector`) to crash whenever a non-valid token would be used to open a session. 