### PR TITLE
Match author with other open source packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:ci": "docker-compose -f docker-compose.yml up --build --exit-code-from test",
     "test:db": "docker-compose -f docker-compose.yml -f docker-compose.local.yml up mssql"
   },
-  "author": "Observable",
+  "author": "Observable, Inc.",
   "license": "ISC",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To fix the grouping on https://observablehq.com/@observablehq/open-source

<img width="567" alt="image" src="https://github.com/observablehq/database-proxy/assets/10444/b82bda99-5413-40eb-bebe-94a8344d58a6">
