### PR TITLE
Alter --standalone secret message

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -153,8 +153,11 @@ export async function add(argv, reset = false) {
   writeConfig(config);
 
   console.log(`Configuration ${reset ? `reset` : `added`} for "${name}"`);
-  if (standalone)
-    console.log(`Secret for DabaseClient("${name}"):\ndb:${name}:${secret}`);
+  if (standalone) {
+    console.log(
+      `Secret for DabaseClient("${name}"):\nOBSERVABLEHQ_DB_SECRET_${name}=${secret}`
+    );
+  }
 }
 
 export function reset(argv) {


### PR DESCRIPTION
Changed the message show at the end of the `add --standalone` and `reset --standalone` commands to reflect current usage