### PR TITLE
Use new `/select-workspace` page for database config

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -54,7 +54,7 @@ export async function add(argv, reset = false) {
         ? "observable.test:5000"
         : "observablehq.com";
     await open(
-      `https://${observable}/settings/databases/choose-account?new&local&host=127.0.0.1&ssl=${
+      `https://${observable}/select-workspace?next=databases-settings&new&local&host=127.0.0.1&ssl=${
         wantsSSL ? "required" : "disabled"
       }&name=${name}`
     );


### PR DESCRIPTION
The previous database-select convenience route (`/settings/databases/choose-account`) [has been replaced](https://github.com/observablehq/observablehq/pull/16444) with a more general-purpose solution (`/select-workspace?next=databases-settings`). Param forwarding should work as expected. The old URL will continue to work via redirect.